### PR TITLE
COOK-4439: Add PHP 5.5.9 support on ubuntu 12.04 using ondrej PPA

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,12 @@ platforms:
   - name: ubuntu-12.04
     run_list:
      - recipe[apt::default]
-
+  - name: ubuntu-13.04
+    run_list:
+     - recipe[apt::default]
+  - name: ubuntu-13.10
+    run_list:
+     - recipe[apt::default]
 suites:
   - name: default
     run_list:
@@ -25,4 +30,4 @@ suites:
   - name: apt-ondrej-repo
     excludes: ["centos-5.10", "centos-6.5", "fedora-19"]
     run_list:
-      - recipe[php::apt_ondrej_php_package]
+      - recipe[php::apt_ondrej_ppa]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,10 +6,23 @@ provisioner:
 
 platforms:
   - name: centos-5.10
+    run_list:
+     - recipe[yum::default]
   - name: centos-6.5
+    run_list:
+     - recipe[yum::default]
   - name: fedora-19
+    run_list:
+     - recipe[yum::default]
+  - name: ubuntu-12.04
+    run_list:
+     - recipe[apt::default]
 
 suites:
   - name: default
     run_list:
-      - recipe[yum::default]
+      - recipe[php::default]
+  - name: apt-ondrej-repo
+    excludes: ["centos-5.10", "centos-6.5", "fedora-19"]
+    run_list:
+      - recipe[php::apt_ondrej_php_package]

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,7 @@ description       'Installs and maintains php and php modules'
 version           '1.4.0'
 
 depends 'build-essential'
+depends 'apt'
 depends 'xml'
 depends 'mysql'
 depends 'yum-epel'

--- a/recipes/apt_ondrej_ppa.rb
+++ b/recipes/apt_ondrej_ppa.rb
@@ -1,0 +1,37 @@
+#
+# Author::  James Cuzella (<james.cuzella@lyraphase.com>)
+# Cookbook Name:: php
+# Recipe:: apt_ondrej_php_package
+#
+# Copyright 2009-2011, Opscode, Inc.
+# Copyright 2014, James Cuzella
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform']
+when 'ubuntu'
+  apt_repository "ondrej-php5-#{node[:lsb][:codename]}" do
+    uri 'http://ppa.launchpad.net/ondrej/php5/ubuntu'
+    distribution node[:lsb][:codename]
+    components [:main]
+    keyserver 'keyserver.ubuntu.com'
+    key 'E5267A6C'
+  end
+
+  package 'php5' do
+    action :upgrade
+  end
+else
+  Chef::Log.warn("#{cookbook_name}::#{recipe_name} only supports ubuntu platform")
+end

--- a/test/integration/apt-ondrej-repo/serverspec/apt_ondrej_ppa_spec.rb
+++ b/test/integration/apt-ondrej-repo/serverspec/apt_ondrej_ppa_spec.rb
@@ -5,6 +5,6 @@ describe package('php5') do
 end
 
 describe command('php --version') do
-  it { should return_stdout /PHP 5\.[3-5]\.[0-9]+/ }
+  it { should return_stdout /PHP 5\.[4-5]\.[0-9]+/ }
 end
 

--- a/test/integration/apt-ondrej-repo/serverspec/apt_ondrej_ppa_spec.rb
+++ b/test/integration/apt-ondrej-repo/serverspec/apt_ondrej_ppa_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe package('php5') do
+  it { should be_installed }
+end
+
+describe command('php --version') do
+  it { should return_stdout /PHP 5\.[3-5]\.[0-9]+/ }
+end
+

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'specinfra/helper'
+
+# Hack to detect OS version at test-kitchen verify time
+SpecInfra::Helper::DetectOS.commands
+os = SpecInfra::Helper::Properties.property[:os_by_host]['localhost']
+
+# Check the right package name depending on OS
+case os[:family]
+when 'RedHat'
+  case os[:release].to_f
+  when 5.10
+    php_pkgname = 'php53'
+  when 6.5
+    php_pkgname = 'php'
+  when 19 # Fedora
+    php_pkgname = 'php'
+  end
+when 'Ubuntu'
+  php_pkgname = 'php5'
+end
+
+describe package(php_pkgname) do
+  it { should be_installed }
+end
+
+describe command('php --version') do
+  it { should return_stdout /PHP 5\.[3-5]\.[0-9]+/ }
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,10 @@
+require 'serverspec'
+
+include Serverspec::Helper::DetectOS
+include Serverspec::Helper::Exec
+
+RSpec.configure do |c|
+  c.before :all do
+    c.os = backend(Serverspec::Commands::Base).check_os
+  end
+end


### PR DESCRIPTION
- Added recipe: php::apt_ondrej_php_package
- Added working serverspec tests, fixed test-kitchen config