### PR TITLE
[COOK-4605] - pecl interaction failures

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -117,7 +117,6 @@ end
 
 def current_installed_version
   @current_installed_version ||= begin
-                                   v = nil
                                    version_check_cmd = "#{@bin} -d "
                                    version_check_cmd << " preferred_state=#{can_haz(@new_resource, "preferred_state")}"
                                    version_check_cmd << " list#{expand_channel(can_haz(@new_resource, "channel"))}"
@@ -142,7 +141,7 @@ def candidate_version
 end
 
 def install_package(name, version)
-  command = "echo \"\r\" | #{@bin} -d"
+  command = "printf \"\r\" | #{@bin} -d"
   command << " preferred_state=#{can_haz(@new_resource, "preferred_state")}"
   command << " install -a#{expand_options(@new_resource.options)}"
   command << " #{prefix_channel(can_haz(@new_resource, "channel"))}#{name}"
@@ -152,7 +151,7 @@ def install_package(name, version)
 end
 
 def upgrade_package(name, version)
-  command = "echo \"\r\" | #{@bin} -d"
+  command = "printf \"\r\" | #{@bin} -d"
   command << " preferred_state=#{can_haz(@new_resource, "preferred_state")}"
   command << " upgrade -a#{expand_options(@new_resource.options)}"
   command << " #{prefix_channel(can_haz(@new_resource, "channel"))}#{name}"


### PR DESCRIPTION
Use printf instead of echo. See the [echo man page](http://www.unix.com/man-page/POSIX/1posix/echo/), particularly the section:
> If the first operand is -n, or if any of
>	      the operands contain a backslash ( '\' ) character, the results are implementation-
>	      defined.

And there are many implementations. Prior to revision ae23f441cac67ecfcfafcd18f66c0e2844409f5c, you had `echo -e` which, in my shell at least, is used to "enable interpretation of backslash escapes" (like `\r`). Now, I guess, you're just piping "\r" to pecl.

`printf` is posix defined and compliant. Also, fixed the headache I was having outlined in [COOK-4605](https://tickets.opscode.com/browse/COOK-4605).