### PR TITLE
Remove quotes from directives

### DIFF
--- a/templates/centos/php.ini.erb
+++ b/templates/centos/php.ini.erb
@@ -1221,5 +1221,5 @@ soap.wsdl_cache_ttl=86400
 ; End:
 
 <% @directives.sort_by { |key, val| key }.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive}=#{value}" %>
 <% end -%>

--- a/templates/debian/php.ini.erb
+++ b/templates/debian/php.ini.erb
@@ -1853,5 +1853,5 @@ ldap.max_links = -1
 ; End:
 
 <% @directives.sort_by { |key, val| key }.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive}=#{value}" %>
 <% end -%>

--- a/templates/default/extension.ini.erb
+++ b/templates/default/extension.ini.erb
@@ -3,5 +3,5 @@
 <%= 'zend_' if zend %>extension=<%= filepath %>
 <% end -%>
 <% @directives.each do |k,v| -%>
-<%= "#{@name}.#{k}=\"#{v}\"" %>
+<%= "#{@name}.#{k}=#{v}" %>
 <% end -%>

--- a/templates/default/php.ini.erb
+++ b/templates/default/php.ini.erb
@@ -1896,5 +1896,5 @@ ldap.max_links = -1
 ; End:
 
 <% @directives.sort_by { |key, val| key }.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive}=#{value}" %>
 <% end -%>

--- a/templates/redhat/php.ini.erb
+++ b/templates/redhat/php.ini.erb
@@ -1221,5 +1221,5 @@ soap.wsdl_cache_ttl=86400
 ; End:
 
 <% @directives.sort_by { |key, val| key }.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive}=#{value}" %>
 <% end -%>

--- a/templates/ubuntu/php.ini.erb
+++ b/templates/ubuntu/php.ini.erb
@@ -1853,5 +1853,5 @@ ldap.max_links = -1
 ; End:
 
 <% @directives.sort_by { |key, val| key }.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive}=#{value}" %>
 <% end -%>

--- a/templates/windows/php.ini.erb
+++ b/templates/windows/php.ini.erb
@@ -1931,5 +1931,5 @@ extension=php_exif.dll
 include_path=".;<%= node['php']['conf_dir'].gsub('/', '\\') %>"
 
 <% @directives.each do |directive, value| -%>
-<%= "#{directive}=\"#{value}\"" %>
+<%= "#{directive}=#{value}" %>
 <% end -%>


### PR DESCRIPTION
There are some directives that can't be in quotes such as error_reporting (see issue #88).

This proposal removes the default quotes. But quotes can be passed if needed inside a variable string.
example:
`node.default['php']['directives']['default_mimetype'] = '"text/html"'`