### PR TITLE
fix typo in providers/pear.rb, refs #95

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -133,7 +133,7 @@ def candidate_version
                            candidate_version_cmd = "#{@bin} -d "
                            candidate_version_cmd << "preferred_state=#{can_haz(@new_resource, "preferred_state")}"
                            candidate_version_cmd << " search#{expand_channel(can_haz(@new_resource, "channel"))}"
-                           candidate_version_cmd << "#{@new_resource.package_name}"
+                           candidate_version_cmd << " #{@new_resource.package_name}"
                            p = shell_out(candidate_version_cmd)
                            response = nil
                            response = grep_for_version(p.stdout, @new_resource.package_name) if p.stdout =~ /\.?Matched packages/i


### PR DESCRIPTION
The typo in this [line](https://github.com/opscode-cookbooks/php/blob/c6a314b5eef964378d40d0c8b660e522b4cc51ab/providers/pear.rb#L136) causes the following to silently fail:
```ruby
php_pear 'apc' do
  action :upgrade
end
```
Output (excerpt from Chef logs):
```
Command 'searchapc' is not valid, try 'pecl help'
[2014-11-03T10:59:42-05:00] DEBUG: php_pear[apc]: Installed version:  Candidate version:
```
Expected output:
```
PACKAGE STABLE/(LATEST) LOCAL
APC     3.1.13 (stable)       Alternative PHP Cache
APCu    4.0.7 (beta)          APCu - APC User Cache
[2014-11-03T10:29:27-05:00] DEBUG: php_pear[apc]: Installed version:  Candidate version: 3.1.13
```