### PR TITLE
Add recompile PHP recipe.

### DIFF
--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -1,0 +1,31 @@
+#
+# Author::  David Kinzer (<dtkinzer@gmail.com>)
+# Cookbook Name:: php
+# Recipe:: recompile
+#
+# Copyright 2014, David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version = node['php']['version']
+configure_options = node['php']['configure_options'].join(' ')
+
+bash 're-build php' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-EOF
+  (cd php-#{version} && make clean)
+  (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
+  (cd php-#{version} && make && make install)
+  EOF
+end

--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -32,7 +32,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/php-#{version}.tar.gz" do
   source "#{node['php']['url']}/php-#{version}.tar.gz/from/this/mirror"
   checksum node['php']['checksum']
   mode '0644'
-  creates "#{Chef::Config[:file_cache_path]}/php-#{version}"
+  not_if { ::File.directory?("#{Chef::Config[:file_cache_path]}/php-#{version}") }
 end
 
 bash 're-build php' do

--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -35,12 +35,17 @@ remote_file "#{Chef::Config[:file_cache_path]}/php-#{version}.tar.gz" do
   action 'create_if_missing'
 end
 
-bash 're-build php' do
+bash 'un-pack php' do
   cwd Chef::Config[:file_cache_path]
+  code "tar -zxf php-#{version}.tar.gz"
+  creates "#{node['php']['url']}/php-#{version}"
+end
+
+bash 're-build php' do
+  cwd "#{Chef::Config[:file_cache_path]}/php-#{version}"
   code <<-EOF
-  tar -zxf php-#{version}.tar.gz
-  (cd php-#{version} && make clean)
-  (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
-  (cd php-#{version} && make && make install)
+  (make clean)
+  (#{ext_dir_prefix} ./configure #{configure_options})
+  (make && make install)
   EOF
 end

--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -24,7 +24,7 @@ ext_dir_prefix = node['php']['ext_dir'] ? "EXTENSION_DIR=#{node['php']['ext_dir'
 
 node['php']['src_deps'].each do |pkg|
   package pkg do
-    action :install
+    action 'install'
   end
 end
 
@@ -32,15 +32,15 @@ remote_file "#{Chef::Config[:file_cache_path]}/php-#{version}.tar.gz" do
   source "#{node['php']['url']}/php-#{version}.tar.gz/from/this/mirror"
   checksum node['php']['checksum']
   mode '0644'
-  not_if { ::File.directory?("#{Chef::Config[:file_cache_path]}/php-#{version}") }
+  action 'create_if_missing'
 end
 
 bash 're-build php' do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
+  tar -zxf php-#{version}.tar.gz
   (cd php-#{version} && make clean)
   (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
   (cd php-#{version} && make && make install)
   EOF
-  only_if { ::File.directory?("#{Chef::Config[:file_cache_path]}/php-#{version}") }
 end

--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -42,4 +42,5 @@ bash 're-build php' do
   (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
   (cd php-#{version} && make && make install)
   EOF
+  only_if { ::File.directory?("#{Chef::Config[:file_cache_path]}/php-#{version}") }
 end

--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -20,6 +20,7 @@
 
 version = node['php']['version']
 configure_options = node['php']['configure_options'].join(' ')
+ext_dir_prefix = node['php']['ext_dir'] ? "EXTENSION_DIR=#{node['php']['ext_dir']}" : ''
 
 bash 're-build php' do
   cwd Chef::Config[:file_cache_path]

--- a/recipes/recompile.rb
+++ b/recipes/recompile.rb
@@ -22,6 +22,19 @@ version = node['php']['version']
 configure_options = node['php']['configure_options'].join(' ')
 ext_dir_prefix = node['php']['ext_dir'] ? "EXTENSION_DIR=#{node['php']['ext_dir']}" : ''
 
+node['php']['src_deps'].each do |pkg|
+  package pkg do
+    action :install
+  end
+end
+
+remote_file "#{Chef::Config[:file_cache_path]}/php-#{version}.tar.gz" do
+  source "#{node['php']['url']}/php-#{version}.tar.gz/from/this/mirror"
+  checksum node['php']['checksum']
+  mode '0644'
+  creates "#{Chef::Config[:file_cache_path]}/php-#{version}"
+end
+
 bash 're-build php' do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF


### PR DESCRIPTION
Sometimes the user wants to be able to simply recompile PHP for whatever
reason.  This recipe provides the user an out of the box way to do this
task.