### PR TITLE
Set ext_conf_dir to /etc/php5/mods-available for ubuntu >=12.10

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,7 +41,16 @@ when 'rhel', 'fedora'
   end
 when 'debian'
   default['php']['conf_dir']      = '/etc/php5/cli'
-  default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
+  case node['platform']
+    when 'ubuntu'
+      if node['platform_version'].to_f >= 12.10
+        default['php']['ext_conf_dir'] = '/etc/php5/mods-available'
+      else
+        default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
+      end
+    else
+      default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
+  end
   default['php']['fpm_user']      = 'www-data'
   default['php']['fpm_group']     = 'www-data'
   default['php']['packages']      = %w{ php5-cgi php5 php5-dev php5-cli php-pear }

--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -192,8 +192,9 @@ end
 def get_extension_dir
   @extension_dir ||= begin
                        # Consider using "pecl config-get ext_dir". It is more cross-platform.
-                       # p = shell_out("php-config --extension-dir")
-                       p = shell_out("#{node['php']['pecl']} config-get ext_dir")
+                       p = shell_out("php-config --extension-dir")
+                       # pecl conf-get ext_dir is not inline with pecl list-files xdebug. See http://pear.php.net/bugs/bug.php?id=18666
+                       # p = shell_out("#{node['php']['pecl']} config-get ext_dir")
                        p.stdout.strip
                      end
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -26,7 +26,7 @@ include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
 
 mysql_client 'default' do
   action :create
-  only_if configure_options =~ /mysql/
+  only_if { configure_options =~ /mysql/ }
 end
 
 pkgs = value_for_platform_family(

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -22,7 +22,6 @@ configure_options = node['php']['configure_options'].join(' ')
 
 include_recipe 'build-essential'
 include_recipe 'xml'
-include_recipe 'mysql::client' if configure_options =~ /mysql/
 include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
 
 pkgs = value_for_platform_family(

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -61,7 +61,7 @@ end
 bash 'build php' do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
-  tar -zxf php-#{version}.tar.gz
+  tar -zxvf php-#{version}.tar.gz
   (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
   (cd php-#{version} && make && make install)
   EOF

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -24,6 +24,11 @@ include_recipe 'build-essential'
 include_recipe 'xml'
 include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
 
+mysql_client 'default' do
+  action :create
+  only_if configure_options =~ /mysql/
+end
+
 pkgs = value_for_platform_family(
   %w{ rhel fedora } => %w{ bzip2-devel libc-client-devel curl-devel freetype-devel gmp-devel libjpeg-devel krb5-devel libmcrypt-devel libpng-devel openssl-devel t1lib-devel mhash-devel },
   %w{ debian ubuntu } => %w{ libbz2-dev libc-client2007e-dev libcurl4-gnutls-dev libfreetype6-dev libgmp3-dev libjpeg62-dev libkrb5-dev libmcrypt-dev libpng12-dev libssl-dev libt1-dev },

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -61,7 +61,7 @@ end
 bash 'build php' do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
-  tar -zxvf php-#{version}.tar.gz
+  tar -zxf php-#{version}.tar.gz
   (cd php-#{version} && #{ext_dir_prefix} ./configure #{configure_options})
   (cd php-#{version} && make && make install)
   EOF


### PR DESCRIPTION
This should take care of the new configuration directory structure for php 5.4 on ubuntu while keeping backwards compatibility with older ubuntu versions.