### PR TITLE
Add php_fpm_pool LWRP and kitchen tests to support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,8 +5,10 @@ provisioner:
   name: chef_zero
 
 platforms:
+  - name: ubuntu-14.04
   - name: centos-5.10
   - name: centos-6.5
+  - name: centos-7.0
   - name: fedora-19
   - name: fedora-20
 
@@ -14,3 +16,12 @@ suites:
   - name: default
     run_list:
       - recipe[php::default]
+  - name: fpm_test
+    run_list:
+      - recipe[php::default]
+      - recipe[fpm_test]
+    excludes:
+      - centos-5.10
+      - centos-6.5
+      - fedora-19
+      - fedora-20

--- a/Berksfile
+++ b/Berksfile
@@ -3,5 +3,5 @@ metadata
 
 group :integration do
   cookbook 'apt', '~> 2.0'
+  cookbook 'fpm_test', :path => './test/cookbooks/fpm_test'
 end
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 php Cookbook
 ============
-Installs and configures PHP 5.3 and the PEAR package management system.  Also includes LWRPs for managing PEAR (and PECL) packages along with PECL channels.
+Installs and configures PHP 5.3 and the PEAR package management system.  Also includes LWRPs for managing PEAR (and PECL) packages, PECL channels, and PHP-FPM pools.
 
 Requirements
 ------------
@@ -150,6 +150,40 @@ php_pear "YAML" do
 end
 ```
 
+### `php_fpm_pool`
+Installs the `php-fpm` package appropriate for your distro (if using packages)
+and configures a FPM pool for you. Currently only supported in Debian-family
+operating systems and CentOS 7 (or at least tested with such, YMMV if you are
+using source).
+
+More info: http://php.net/manual/en/install.fpm.php
+
+#### Actions
+- :install: Installs the FPM pool (default).
+- :uninstall: Removes the FPM pool.
+
+#### Attribute Parameters
+- pool_name: name attribute. The name of the FPM pool.
+- listen: The listen address. Default: `/var/run/php5-fpm.sock`
+- user: The user to run the FPM under. Default should be the webserver user for
+  your distro.
+- group: The group to run the FPM under. Default should be the webserver group
+  for your distro.
+- process_manager: Process manager to use - see
+  http://php.net/manual/en/install.fpm.configuration.php. Default: `dynamic`
+- max_children: Max children to scale to. Default: 5
+- start_servers: Number of servers to start the pool with. Default: 2
+- min_spare_servers: Minimum number of servers to have as spares. Default: 1
+- max_spare_servers: Maximum number of servers to have as spares. Default: 3
+- chdir: The startup working directory of the pool. Default: `/`
+
+#### Examples
+```ruby
+# Install a FPM pool named "default"
+php_fpm_pool "default" do
+  action :install
+end
+```
 
 Recipes
 -------
@@ -269,29 +303,29 @@ Microsoft Windows platform only to correct an (upstream bug)[http://pear.php.net
 `go-pear.phar` is licensed under the (PHP License version 2.02)[http://www.php.net/license/2_02.txt]:
 
 ```
--------------------------------------------------------------------- 
+--------------------------------------------------------------------
                   The PHP License, version 2.02
 Copyright (c) 1999 - 2002 The PHP Group. All rights reserved.
--------------------------------------------------------------------- 
+--------------------------------------------------------------------
 
 Redistribution and use in source and binary forms, with or without
 modification, is permitted provided that the following conditions
 are met:
 
   1. Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer. 
- 
-  2. Redistributions in binary form must reproduce the above 
-     copyright notice, this list of conditions and the following 
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
      disclaimer in the documentation and/or other materials provided
      with the distribution.
- 
-  3. The name "PHP" must not be used to endorse or promote products 
-     derived from this software without prior permission from the 
+
+  3. The name "PHP" must not be used to endorse or promote products
+     derived from this software without prior permission from the
      PHP Group.  This does not apply to add-on libraries or tools
      that work in conjunction with PHP.  In such a case the PHP
      name may be used to indicate that the product supports PHP.
- 
+
   4. The PHP Group may publish revised and/or new versions of the
      license from time to time. Each version will be given a
      distinguishing version number.
@@ -318,30 +352,30 @@ are met:
      modify the Zend Engine, or any portion thereof, your use of the
      separated or modified Zend Engine software shall not be governed
      by this license, and instead shall be governed by the license
-     set forth at http://www.zend.com/license/ZendLicense/. 
+     set forth at http://www.zend.com/license/ZendLicense/.
 
 
 
-THIS SOFTWARE IS PROVIDED BY THE PHP DEVELOPMENT TEAM ``AS IS'' AND 
+THIS SOFTWARE IS PROVIDED BY THE PHP DEVELOPMENT TEAM ``AS IS'' AND
 ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
 PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE PHP
-DEVELOPMENT TEAM OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+DEVELOPMENT TEAM OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
 
--------------------------------------------------------------------- 
+--------------------------------------------------------------------
 
 This software consists of voluntary contributions made by many
 individuals on behalf of the PHP Group.
 
 The PHP Group can be contacted via Email at group@php.net.
 
-For more information on the PHP Group and the PHP project, 
+For more information on the PHP Group and the PHP project,
 please see <http://www.php.net>.
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,13 +38,25 @@ when 'rhel', 'fedora'
     default['php']['packages'] = %w{ php53 php53-devel php53-cli php-pear }
   else
     default['php']['packages'] = %w{ php php-devel php-cli php-pear }
+    default['php']['fpm_package']   = 'php-fpm'
+    default['php']['fpm_pooldir']   = '/etc/php-fpm.d'
+    default['php']['fpm_default_conf']   = '/etc/php-fpm.d/www.conf'
+    default['php']['fpm_service']   = 'php-fpm'
+    if node['php']['install_method'] == 'package'
+      default['php']['fpm_user']      = 'apache'
+      default['php']['fpm_group']     = 'apache'
+    end
   end
 when 'debian'
   default['php']['conf_dir']      = '/etc/php5/cli'
   default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
+  default['php']['packages']      = %w{ php5-cgi php5 php5-dev php5-cli php-pear }
+  default['php']['fpm_package']   = 'php5-fpm'
+  default['php']['fpm_pooldir']   = '/etc/php5/fpm/pool.d'
   default['php']['fpm_user']      = 'www-data'
   default['php']['fpm_group']     = 'www-data'
-  default['php']['packages']      = %w{ php5-cgi php5 php5-dev php5-cli php-pear }
+  default['php']['fpm_service']   = 'php5-fpm'
+  default['php']['fpm_default_conf']   = '/etc/php5/fpm/pool.d/www.conf'
 when 'suse'
   default['php']['conf_dir']      = '/etc/php5/cli'
   default['php']['ext_conf_dir']  = '/etc/php5/conf.d'
@@ -68,7 +80,7 @@ when 'windows'
                                         ext_php_pgsql ext_php_soap ext_php_sockets
                                         ext_php_sqlite3 ext_php_tidy ext_php_xmlrpc
                                       }
-  default['php']['package_options'] = "" # Use this to customise your yum or apt command                                     
+  default['php']['package_options'] = "" # Use this to customise your yum or apt command
   default['php']['pear']          = 'pear.bat'
   default['php']['pecl']          = 'pecl.bat'
 else

--- a/providers/fpm_pool.rb
+++ b/providers/fpm_pool.rb
@@ -1,0 +1,86 @@
+#
+# Author:: Chris Marchesi <cmarchesi@paybyphone.com>
+# Cookbook Name:: php
+# Provider:: fpm_pool
+#
+# Copyright:: 2015, Opscode, Inc <legal@opscode.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def whyrun_supported?
+  true
+end
+
+def install_fpm_package
+  # Install the FPM pacakge for this platform, if it's available
+  # Fail the run if it's an unsupported OS (FPM pacakge name not populated)
+  # also, this is skipped for source
+  if node['php']['install_method'] == 'source'
+    return
+  end
+  if node['php']['fpm_package'] == nil
+    raise 'PHP-FPM package not found (you probably have an unsupported distro)'
+  else
+    file node['php']['fpm_default_conf'] do
+      action :nothing
+    end
+    package node['php']['fpm_package'] do
+      action :install
+      notifies :delete, "file[#{node['php']['fpm_default_conf']}]"
+    end
+  end
+end
+
+def register_fpm_service
+  service node['php']['fpm_service'] do
+    action :enable
+  end
+end
+
+action :install do
+  # Ensure the FPM pacakge is installed, and the service is registered
+  install_fpm_package()
+  register_fpm_service()
+  # I wanted to have this as a function in itself, but doing this seems to
+  # break testing suites?
+  t = template "#{node['php']['fpm_pooldir']}/#{new_resource.pool_name}.conf" do
+    source 'fpm-pool.conf.erb'
+    action :create
+    cookbook 'php'
+    variables ({
+      :fpm_pool_name => new_resource.pool_name,
+      :fpm_pool_user => new_resource.user,
+      :fpm_pool_group => new_resource.group,
+      :fpm_pool_listen => new_resource.listen,
+      :fpm_pool_manager => new_resource.process_manager,
+      :fpm_pool_max_children => new_resource.max_children,
+      :fpm_pool_start_servres => new_resource.start_servers,
+      :fpm_pool_min_spare_servers => new_resource.min_spare_servers,
+      :fpm_pool_max_spare_servers => new_resource.max_spare_servers,
+      :fpm_pool_chdir => new_resource.chdir
+    })
+    notifies :restart, "service[#{node['php']['fpm_package']}]"
+  end
+  new_resource.updated_by_last_action(t.updated_by_last_action?)
+end
+
+action :uninstall do
+  # Ensure the FPM pacakge is installed, and the service is registered
+  register_fpm_service()
+  # Delete the FPM pool.
+  f = file "#{node['php']['fpm_pooldir']}/#{new_resource.pool_name}" do
+    action :delete
+  end
+  new_resource.updated_by_last_action(f.updated_by_last_action?)
+end

--- a/resources/fpm_pool.rb
+++ b/resources/fpm_pool.rb
@@ -1,0 +1,33 @@
+#
+# Author:: Chris Marchesi <cmarchesi@paybyphone.com>
+# Cookbook Name:: php
+# Resource:: fpm_pool
+#
+# Copyright:: 2015, Opscode, Inc <legal@opscode.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default_action :install
+actions :install, :uninstall
+
+attribute :pool_name, :kind_of => String, :name_attribute => true
+attribute :listen, :default => '/var/run/php5-fpm.sock'
+attribute :user, :kind_of => String, :default => node['php']['fpm_user']
+attribute :group, :kind_of => String, :default => node['php']['fpm_user']
+attribute :process_manager, :kind_of => String, :default => 'dynamic'
+attribute :max_children, :kind_of => Integer, :default => 5
+attribute :start_servers, :kind_of => Integer, :default => 2
+attribute :min_spare_servers, :kind_of => Integer, :default => 1
+attribute :max_spare_servers, :kind_of => Integer, :default => 3
+attribute :chdir, :kind_of => String, :default => '/'

--- a/templates/default/fpm-pool.conf.erb
+++ b/templates/default/fpm-pool.conf.erb
@@ -1,0 +1,12 @@
+[<%= @fpm_pool_name %>]
+user = <%= @fpm_pool_user %>
+group = <%= @fpm_pool_group %>
+listen = <%= @fpm_pool_listen %>
+listen.owner = <%= @fpm_pool_user %>
+listen.group = <%= @fpm_pool_group %>
+pm = <%= @fpm_pool_manager %>
+pm.max_children = <%= @fpm_pool_max_children %>
+pm.start_servers = <%= @fpm_pool_start_servers %>
+pm.min_spare_servers = <%= @fpm_pool_min_spare_servers %>
+pm.max_spare_servers = <%= @fpm_pool_max_spare_servers %>
+chdir = <%= @fpm_pool_chdir %>

--- a/test/cookbooks/fpm_test/metadata.rb
+++ b/test/cookbooks/fpm_test/metadata.rb
@@ -1,0 +1,9 @@
+name              'fpm_test'
+maintainer        'Opscode, Inc.'
+maintainer_email  'cookbooks@opscode.com'
+license           'Apache 2.0'
+description       'Test for FPM LWRP in PHP cookbook'
+version           '1.0.0'
+
+depends 'apt'
+depends 'php'

--- a/test/cookbooks/fpm_test/recipes/default.rb
+++ b/test/cookbooks/fpm_test/recipes/default.rb
@@ -1,0 +1,8 @@
+# Test cookbook for the FPM LWRP
+
+include_recipe 'apt'
+include_recipe 'php'
+
+php_fpm_pool 'test-pool' do
+  action :install
+end


### PR DESCRIPTION
Hey guys,

This request adds a new LWRP - `php_fpm_pool`.

I figured this was a natural fit for the cookbook, the LWRP will install the appropriate `php-fpm` package for the distro (currently umbrella supported under Debian OSes (ie: Ubuntu LTS) and CentOS >=6). I have tested this on CentOS 7 and Ubuntu 14.04 using Kitchen.

The idea being is that you can get FPM up and running and then configure nginx using https://github.com/miketheman/nginx.

I am open to anything in regards to style or whatever that may need fixing - let me know what needs to happen to get this merged.

Thanks,

--Chris
