### PR TITLE
Fix permissions/mode of [php][ext_conf_dir]

### DIFF
--- a/providers/pear.rb
+++ b/providers/pear.rb
@@ -240,7 +240,7 @@ def manage_pecl_ini(name, action, directives, zend_extensions)
   directory "#{node['php']['ext_conf_dir']}" do
     owner 'root'
     group 'root'
-    mode '0644'
+    mode '0755'
     recursive true
   end
 


### PR DESCRIPTION
Since the resource pointed by `node['php']['ext_conf_dir']` will certainly be a directory it will need execution permissions. Otherwise when activating an extension for CLI for instance by creating a symlink under `/etc/php5/cli/conf.d` it won't be able to read and import it.